### PR TITLE
Add placeholder type to form fields

### DIFF
--- a/KeePassRPC/DataExchangeModel.cs
+++ b/KeePassRPC/DataExchangeModel.cs
@@ -20,6 +20,8 @@ namespace KeePassRPC.DataExchangeModel
                 type = "Username";
             else if (fft == FormFieldType.FFTcheckbox)
                 type = "Checkbox";
+            else if (fft == FormFieldType.FFTplaceholder)
+                type = "Placeholder";
             if (!titleCase)
                 return type.ToLower();
             return type;
@@ -41,6 +43,8 @@ namespace KeePassRPC.DataExchangeModel
                 fft = FormFieldType.FFTusername;
             else if (type == "checkbox")
                 fft = FormFieldType.FFTcheckbox;
+            else if (type == "placeholder")
+                fft = FormFieldType.FFTplaceholder;
             return fft;
         }
     }
@@ -78,7 +82,7 @@ namespace KeePassRPC.DataExchangeModel
     }
 
     public enum LoginSearchType { LSTall, LSTnoForms, LSTnoRealms }
-    public enum FormFieldType { FFTradio, FFTusername, FFTtext, FFTpassword, FFTselect, FFTcheckbox } // ..., HTML 5, etc.
+    public enum FormFieldType { FFTradio, FFTusername, FFTtext, FFTpassword, FFTselect, FFTcheckbox, FFTplaceholder } // ..., HTML 5, etc.
     // FFTusername is special type because bultin FF supports with only username and password
 
     public struct MatchAccuracy

--- a/KeePassRPC/Forms/KeeFoxFieldForm.Designer.cs
+++ b/KeePassRPC/Forms/KeeFoxFieldForm.Designer.cs
@@ -84,7 +84,8 @@
             "Password",
             "Radio",
             "Checkbox",
-            "Select"});
+            "Select",
+            "Placeholder"});
             this.comboBox1.Location = new System.Drawing.Point(328, 8);
             this.comboBox1.Name = "comboBox1";
             this.comboBox1.Size = new System.Drawing.Size(75, 21);

--- a/KeePassRPC/Forms/KeeFoxFieldForm.cs
+++ b/KeePassRPC/Forms/KeeFoxFieldForm.cs
@@ -57,7 +57,9 @@ namespace KeePassRPC.Forms
                 else if (type == FormFieldType.FFTusername)
                     comboBox1.Text = "Username";
                 else if (type == FormFieldType.FFTcheckbox)
-                    comboBox1.Text = "Checkbox";                    
+                    comboBox1.Text = "Checkbox";
+                else if (type == FormFieldType.FFTplaceholder)
+                    comboBox1.Text = "Placeholder";
             }
             textBox1.Text = Name = name;
             textBox2.Text = Value = value;
@@ -98,6 +100,8 @@ namespace KeePassRPC.Forms
                 Type = FormFieldType.FFTusername;
             else if (comboBox1.Text == "Checkbox")
                 Type = FormFieldType.FFTcheckbox;
+            else if (comboBox1.Text == "Placeholder")
+                Type = FormFieldType.FFTplaceholder;
         }
     }
 }

--- a/KeePassRPC/KeePassRPCExt.cs
+++ b/KeePassRPC/KeePassRPCExt.cs
@@ -32,7 +32,7 @@ namespace KeePassRPC
     public sealed class KeePassRPCExt : Plugin
     {
         // version information
-        public static readonly Version PluginVersion = new Version(1, 7, 3);
+        public static readonly Version PluginVersion = new Version(1, 7, 4);
 
         public override string UpdateUrl
         {
@@ -1421,6 +1421,11 @@ You can recreate these entries by selecting Tools / Insert KeeFox tutorial sampl
                     {
                         formFieldList.Add(new FormField(fieldName,
                 fieldName, GetFormFieldValue(pwe, fieldName, db), FormFieldType.FFTcheckbox, fieldId, fieldPage));
+                    }
+                    else if (pweValue == "placeholder")
+                    {
+                        formFieldList.Add(new FormField(fieldName,
+                fieldName, GetFormFieldValue(pwe, fieldName, db), FormFieldType.FFTplaceholder, fieldId, fieldPage));
                     }
                 }
                 else if (pweKey == "Alternative URLs" || pweKey == "KPRPC Alternative URLs")

--- a/KeePassRPC/KeePassRPCService.cs
+++ b/KeePassRPC/KeePassRPCService.cs
@@ -324,6 +324,14 @@ namespace KeePassRPC
                                 usernameFound = true;
                             }
                         }
+                        else if (ff.Type == FormFieldType.FFTplaceholder)
+                        {
+                            string ffValue = KeePassRPCPlugin.GetPwEntryStringFromDereferencableValue(pwe, ff.Value, db);
+                            if (!string.IsNullOrEmpty(ffValue))
+                            {
+                                formFieldList.Add(new FormField(ff.Name, "Placeholder", ffValue, FormFieldType.FFTtext, ff.Id, ff.Page));
+                            }
+                        }
                         else
                             formFieldList.Add(new FormField(ff.Name, ff.Name, ff.Value, ff.Type, ff.Id, ff.Page));
                     }

--- a/KeePassRPC/Properties/AssemblyInfo.cs
+++ b/KeePassRPC/Properties/AssemblyInfo.cs
@@ -19,4 +19,4 @@ using System.Runtime.InteropServices;
 
 // Assembly version information
 [assembly: AssemblyVersion("2.0.34.*")]
-[assembly: AssemblyFileVersion("1.7.3.0")] // also change PluginVersion in KeePassRPCExt.cs!
+[assembly: AssemblyFileVersion("1.7.4.0")] // also change PluginVersion in KeePassRPCExt.cs!


### PR DESCRIPTION
add support for the new type to the service and model.
Info: now you can use values like {TOTP} with the placeholder field type.

Fixes:   #17, #8, #11 
Browser Repo issue: https://github.com/kee-org/browser-addon/issues/49
