### PR TITLE
Fix issue #148 of kee-org/keepassrpc

### DIFF
--- a/KeePassRPC/Models/Persistent/EntryConfigv1.cs
+++ b/KeePassRPC/Models/Persistent/EntryConfigv1.cs
@@ -272,7 +272,7 @@ namespace KeePassRPC.Models.Persistent
                 }
             }
 
-            if (!usernameFound)
+            if (!usernameFound && formFieldList != null)
             {
                 fields.Add(new Field
                 {
@@ -282,7 +282,7 @@ namespace KeePassRPC.Models.Persistent
                     MatcherConfigs = new [] { new FieldMatcherConfig { MatcherType = FieldMatcherType.UsernameDefaultHeuristic } }
                 });
             }
-            if (!passwordFound)
+            if (!passwordFound && formFieldList != null)
             {
                 fields.Add(new Field
                 {

--- a/KeePassRPC/Models/Persistent/EntryConfigv2.cs
+++ b/KeePassRPC/Models/Persistent/EntryConfigv2.cs
@@ -1,5 +1,6 @@
 using System;
 using KeePassRPC.Models.Shared;
+using System.Linq;
 
 namespace KeePassRPC.Models.Persistent
 {
@@ -41,7 +42,7 @@ namespace KeePassRPC.Models.Persistent
         {
             if (ReferenceEquals(null, other)) return false;
             if (ReferenceEquals(this, other)) return true;
-            return Version == other.Version && Equals(AltUrls, other.AltUrls) && Equals(BlockedUrls, other.BlockedUrls) && Equals(RegExBlockedUrls, other.RegExBlockedUrls) && Equals(RegExUrls, other.RegExUrls) && HttpRealm == other.HttpRealm && Equals(AuthenticationMethods, other.AuthenticationMethods) && Behaviour == other.Behaviour && Equals(MatcherConfigs, other.MatcherConfigs) && Equals(Fields, other.Fields);
+            return Version == other.Version && Enumerable.SequenceEqual(AltUrls, other.AltUrls) && Enumerable.SequenceEqual(BlockedUrls, other.BlockedUrls) && Enumerable.SequenceEqual(RegExBlockedUrls, other.RegExBlockedUrls) && Enumerable.SequenceEqual(RegExUrls, other.RegExUrls) && HttpRealm == other.HttpRealm && Enumerable.SequenceEqual(AuthenticationMethods, other.AuthenticationMethods) && Behaviour == other.Behaviour && Enumerable.SequenceEqual(MatcherConfigs, other.MatcherConfigs) && Enumerable.SequenceEqual(Fields, other.Fields);
         }
 
         public override bool Equals(object obj)

--- a/KeePassRPC/Models/Persistent/EntryConfigv2.cs
+++ b/KeePassRPC/Models/Persistent/EntryConfigv2.cs
@@ -1,6 +1,6 @@
 using System;
 using KeePassRPC.Models.Shared;
-using System.Linq;
+using System.Collections;
 
 namespace KeePassRPC.Models.Persistent
 {
@@ -42,7 +42,7 @@ namespace KeePassRPC.Models.Persistent
         {
             if (ReferenceEquals(null, other)) return false;
             if (ReferenceEquals(this, other)) return true;
-            return Version == other.Version && Enumerable.SequenceEqual(AltUrls, other.AltUrls) && Enumerable.SequenceEqual(BlockedUrls, other.BlockedUrls) && Enumerable.SequenceEqual(RegExBlockedUrls, other.RegExBlockedUrls) && Enumerable.SequenceEqual(RegExUrls, other.RegExUrls) && HttpRealm == other.HttpRealm && Enumerable.SequenceEqual(AuthenticationMethods, other.AuthenticationMethods) && Behaviour == other.Behaviour && Enumerable.SequenceEqual(MatcherConfigs, other.MatcherConfigs) && Enumerable.SequenceEqual(Fields, other.Fields);
+            return Version == other.Version && StructuralComparisons.StructuralEqualityComparer.Equals(AltUrls, other.AltUrls) && StructuralComparisons.StructuralEqualityComparer.Equals(BlockedUrls, other.BlockedUrls) && StructuralComparisons.StructuralEqualityComparer.Equals(RegExBlockedUrls, other.RegExBlockedUrls) && StructuralComparisons.StructuralEqualityComparer.Equals(RegExUrls, other.RegExUrls) && HttpRealm == other.HttpRealm && StructuralComparisons.StructuralEqualityComparer.Equals(AuthenticationMethods, other.AuthenticationMethods) && Behaviour == other.Behaviour && StructuralComparisons.StructuralEqualityComparer.Equals(MatcherConfigs, other.MatcherConfigs) && StructuralComparisons.StructuralEqualityComparer.Equals(Fields, other.Fields);
         }
 
         public override bool Equals(object obj)

--- a/KeePassRPC/Models/Shared/Field.cs
+++ b/KeePassRPC/Models/Shared/Field.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 
 namespace KeePassRPC.Models.Shared
 {
@@ -17,7 +18,7 @@ namespace KeePassRPC.Models.Shared
         {
             if (ReferenceEquals(null, other)) return false;
             if (ReferenceEquals(this, other)) return true;
-            return Uuid.Equals(other.Uuid) && Name == other.Name && ValuePath == other.ValuePath && Value == other.Value && Page == other.Page && Type == other.Type && PlaceholderHandling == other.PlaceholderHandling && Equals(MatcherConfigs, other.MatcherConfigs);
+            return Uuid.Equals(other.Uuid) && Name == other.Name && ValuePath == other.ValuePath && Value == other.Value && Page == other.Page && Type == other.Type && PlaceholderHandling == other.PlaceholderHandling && Enumerable.SequenceEqual(MatcherConfigs, other.MatcherConfigs);
         }
 
         public override bool Equals(object obj)

--- a/KeePassRPC/Models/Shared/Field.cs
+++ b/KeePassRPC/Models/Shared/Field.cs
@@ -1,5 +1,5 @@
 using System;
-using System.Linq;
+using System.Collections;
 
 namespace KeePassRPC.Models.Shared
 {
@@ -18,7 +18,7 @@ namespace KeePassRPC.Models.Shared
         {
             if (ReferenceEquals(null, other)) return false;
             if (ReferenceEquals(this, other)) return true;
-            return Uuid.Equals(other.Uuid) && Name == other.Name && ValuePath == other.ValuePath && Value == other.Value && Page == other.Page && Type == other.Type && PlaceholderHandling == other.PlaceholderHandling && Enumerable.SequenceEqual(MatcherConfigs, other.MatcherConfigs);
+            return Uuid.Equals(other.Uuid) && Name == other.Name && ValuePath == other.ValuePath && Value == other.Value && Page == other.Page && Type == other.Type && PlaceholderHandling == other.PlaceholderHandling && StructuralComparisons.StructuralEqualityComparer.Equals(MatcherConfigs, other.MatcherConfigs);
         }
 
         public override bool Equals(object obj)


### PR DESCRIPTION
Hi,

Entries were altered very often and without user interaction, because form initialization was not handled. In addition comparing of the entry config did not work as expected.

Arrays were not handled properly
Converting v1 to v2 always created default fields with unique uuids

See also discussion at https://forum.kee.pm/t/keepassrpc-asks-to-save-when-no-known-changes-were-made/4580/10

Kind regards,
  Andre